### PR TITLE
Restructure code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/PeeringDB.py
+++ b/PeeringDB.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import requests
+
+
+API_BASE_URL = 'https://beta.peeringdb.com/api/'
+
+def getPeeringDetails(asn):
+    """Get peering details for ASN"""
+    request = requests.get(API_BASE_URL + 'asn/%s' % asn)
+    json_data = request.json()
+    result = {}
+    for d in json_data['data']:
+        for n in d['netixlan_set']:
+            data = { 'ipv4': n['ipaddr4'], 'ipv6': n['ipaddr6']}
+            result[n['ixlan_id']] = data
+    return {"asn": asn, "result": result}
+
+
+def mapIdToIx(ixlan_id):
+    """Map IX number to human readable"""
+    api_data = requests.get(API_BASE_URL + 'ixlan/%s' % ixlan_id)
+    json_data = api_data.json()
+    for x in json_data['data']:
+        return x['ix']['name']

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is a rewrite of the peeringmatcher found on github, this one is using the new peeringdb API for all requests. Printing all output to a pretty table.
 
 Install dependencies with Pip:
+
     pip install -r requirements.txt
 
 Tested with Python 2.7.9, run with:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # peeringmatcher
-Peeringmatcher
 
 This is a rewrite of the peeringmatcher found on github, this one is using the new peeringdb API for all requests. Printing all output to a pretty table.
 
+Install dependencies with Pip:
+    pip install -r requirements.txt
+
 Tested with Python 2.7.9, run with:
 
-./peeringmatcher.py < asn1 > < asn2 >
+    ./peeringmatcher.py < asn1 > < asn2 >
 
 Where your AS is the first one.

--- a/peeringmatcher.py
+++ b/peeringmatcher.py
@@ -1,65 +1,61 @@
 #!/usr/bin/python
-
 # -*- coding: utf-8 -*-
+"""
+Example:
+    ./peeringmatcher.py <asn1> <asn2>
+"""
 
+import argparse
 import json
-import requests
 import sys
-from prettytable import PrettyTable
-import paramiko
 import time
 
+from prettytable import PrettyTable
+import paramiko
+
+from PeeringDB import *
+
+
+def parseArguments():
+    """Parse command line arguments"""
+    def ASN(value):
+        ivalue = int(value)
+        if ivalue < 0:
+             raise argparse.ArgumentTypeError("%s is not a valid ASN" % value)
+        return ivalue
+    parser = argparse.ArgumentParser(
+        description = __doc__,
+        formatter_class = argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument('asn1', type = ASN)
+    parser.add_argument('asn2', type = ASN)
+    return parser.parse_args()
+
+
+def printTable(asn1, asn2):
+    """Print table for two ASNs"""
+    # Create a pretty table
+    x = PrettyTable(["IXLAN", "ASN", "IPv4", "IPv6"])
+    x.padding_width = 1
+
+    # Populate the table
+    for key in set(asn1['result'].keys()) & set(asn2['result'].keys()):
+        # Map IX number to human readable
+        ix = mapIdToIx(str(key))
+        x.add_row([ix, asn1['asn'], asn1['result'][key]['ipv4'], asn1["result"][key]['ipv6']])
+        x.add_row([ix, asn1['asn'], asn2['result'][key]['ipv4'], asn2['result'][key]['ipv6']])
+        # How do I make an empty row!? Ugly below...
+        x.add_row(["", "", "", ""])
+    # Print pretty table
+    print x
+
+
 def main():
-    if len(sys.argv) < 3:
-        print "Not enough arguments."
-        print
-        print "Example:"
-        print "./peeringmatcher.py <asn1> <asn2>"
-        print
-    if len(sys.argv) < 3:
-        print "Too many arguments."
-        print
-        print "Example:"
-        print "./peeringmatcher.py <asn1> <asn2>"
-        print
-    elif len(sys.argv) == 3:
-        api_data_asn1 = requests.get('https://beta.peeringdb.com/api/asn/' + sys.argv[1])
-        api_data_asn2 = requests.get('https://beta.peeringdb.com/api/asn/' + sys.argv[2])
-        json_data_asn1 = api_data_asn1.json()
-        json_data_asn2 = api_data_asn2.json()
+    args = parseArguments()
+    asn1 = getPeeringDetails(args.asn1)
+    asn2 = getPeeringDetails(args.asn2)
+    printTable(asn1, asn2)
 
-        asn1 = dict()
-        asn2 = dict()
-        for x in json_data_asn1['data']:
-            for y in x['netixlan_set']:
-                data = { 'ipv4': y['ipaddr4'], 'ipv6': y['ipaddr6']}
-                asn1[y['ixlan_id']] = data
-        
-        for x in json_data_asn2['data']:
-            for y in x['netixlan_set']:
-                data = { 'ipv4': y['ipaddr4'], 'ipv6': y['ipaddr6']}
-                asn2[y['ixlan_id']] = data
-
-        # Create a pretty table
-        x = PrettyTable(["IXLAN", "ASN", "IPv4", "IPv6"])
-        x.padding_width = 1
-
-        # Populate the table
-        for key in set(asn1.keys()) & set(asn2.keys()):
-            # Map IX number to human readable
-            ix = map_id_to_ix(str(key))
-            x.add_row([ix, sys.argv[1], asn1[key]['ipv4'], asn1[key]['ipv6']])
-            x.add_row([ix, sys.argv[2], asn2[key]['ipv4'], asn2[key]['ipv6']])
-            # How do I make an empty row!? Ugly below...
-            x.add_row(["", "", "", ""])
-        # Print pretty table
-        print x
-
-def map_id_to_ix(ixlan_id):
-    api_data = requests.get('https://beta.peeringdb.com/api/ixlan/' + ixlan_id)
-    json_data = api_data.json()
-    for x in json_data['data']:
-        return x['ix']['name']
 
 if __name__ == '__main__':
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+ecdsa==0.13
+paramiko==1.16.0
+prettytable==0.7.2
+pycrypto==2.6.1
+requests==2.9.1
+wheel==0.24.0


### PR DESCRIPTION
All in all looks very good :smile: Glad you're enjoying Python.

I tried to change as little as possible, while still trying to show what some of the best practises are.
### Moving PeeringDB API code to its own file

Simply creating a new file called `PeeringDB.py` and in the main script do:

```
from PeeringDB import *
```

This means that you can re-use the PeeringDB API for other scripts in the future easily.
### Re-structuring `main()`

Nice to see this! 

```
if __name__ == '__main__':
    main()
```

It means you could import the `peeringmatcher` code into another Python script and it would not trigger your main code to run, so you could re-use the functions easily.

I just re-structured `main()` to be a bit easier to read, by splitting it out into a few helper methods:
1. Parse arguments using helper `parseArguments()` (explained in the next section)
2. Get peering details from the PeeringDB API
3. Call `printTable()` to get a nice table printed

`printTable` is pretty much what you had in the `main()` before.
### Argument parser

Your argument parsing was good and correct. I just changed it for [the built-in `argparse`](https://docs.python.org/2.7/library/argparse.html), which helps you with the logic.

In this simple case it doesn't really matter, but if you start having scripts with more arguments and different types, it can become a bit tricky to get the parsing right.

The relevant code is:

```
parser = argparse.ArgumentParser(
    description = __doc__,
    formatter_class = argparse.RawDescriptionHelpFormatter
)
parser.add_argument('asn1', type = ASN)
parser.add_argument('asn2', type = ASN)
return parser.parse_args()
```

The `description = __doc__` option means that the "docstring" at the top of the file will be used when outputting the help text:

```
$ ./peeringmatcher.py -h
usage: peeringmatcher.py [-h] asn1 asn2

Example:
    ./peeringmatcher.py <asn1> <asn2>

positional arguments:
  asn1
  asn2

optional arguments:
  -h, --help  show this help message and exit
```

The `type = ASN` means that the function `ASN` will be used to test if the argument is valid. In this case I assumed ASN had to be a positive number, but you could validate using regexp or any other logic you want (MAC addresses, IP addresses, etc.).
### .gitignore

I created a `.gitignore` file that is specific for Python projects. Whenever git looks at what files to suggest adding for tracking, it will ignore the ones that matches `.gitignore`. There is [a really good repository](https://github.com/github/gitignore) which has `.gitignore` suggestions for most common languages.

When you run a Python script it will create a Python bytecode file (`.pyc`), you don't want those accidentally checked into Git, so this `.gitignore` helps with that.
